### PR TITLE
LPS-168356 Add autom. test | FDSCustomView#NameCanBeUpdated

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
@@ -24,6 +24,12 @@ definition {
 			value1 = "${key_filter}");
 	}
 
+	macro assertMenuItem {
+		AssertElementPresent(
+			key_itemName = "${key_menuItem}",
+			locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
+	}
+
 	macro changeCustomView {
 		Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
 
@@ -125,6 +131,22 @@ definition {
 		Click(
 			locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW",
 			value1 = "${key_itemName}");
+	}
+
+	macro renameView {
+		Click(locator1 = "FrontendDataSet#SELECT_OPTION_HEADER");
+
+		Click(
+			key_itemName = "Rename View",
+			locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
+
+		Type(
+			locator1 = "FrontendDataSet#INPUT_CUSTOM_VIEW_NAME",
+			value1 = "${key_nameView}");
+
+		Click(
+			key_name = "Save",
+			locator1 = "Button#GENERAL_BUTTON_MODAL_FOOTER");
 	}
 
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
@@ -93,6 +93,22 @@ definition {
 		return "${dataSetValue}";
 	}
 
+	macro renameView {
+		Click(locator1 = "FrontendDataSet#SELECT_OPTION_HEADER");
+
+		Click(
+			key_itemName = "Rename View",
+			locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
+
+		Type(
+			locator1 = "FrontendDataSet#INPUT_CUSTOM_VIEW_NAME",
+			value1 = "${key_nameView}");
+
+		Click(
+			key_name = "Save",
+			locator1 = "Button#GENERAL_BUTTON_MODAL_FOOTER");
+	}
+
 	macro saveCustomView {
 		Click(locator1 = "FrontendDataSet#SELECT_OPTION_HEADER");
 
@@ -131,22 +147,6 @@ definition {
 		Click(
 			locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW",
 			value1 = "${key_itemName}");
-	}
-
-	macro renameView {
-		Click(locator1 = "FrontendDataSet#SELECT_OPTION_HEADER");
-
-		Click(
-			key_itemName = "Rename View",
-			locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
-
-		Type(
-			locator1 = "FrontendDataSet#INPUT_CUSTOM_VIEW_NAME",
-			value1 = "${key_nameView}");
-
-		Click(
-			key_name = "Save",
-			locator1 = "Button#GENERAL_BUTTON_MODAL_FOOTER");
 	}
 
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
@@ -239,24 +239,6 @@ definition {
 		}
 	}
 
-	@description = "LPS-164616. Assert that it's possible to create A new custom view and selected as current view"
-	@priority = "4"
-	test HasOptionToEditName {
-		task ("And Given created custom view") {
-			FDSCustomView.createNewView(key_nameView = "TEST");
-		}
-
-		task ("When open ellisis next to custom view") {
-			Click(locator1 = "FrontendDataSet#ELLIPSIS");
-		}
-
-		task ("Then actions to edit custom view name is available") {
-			AssertElementPresent(
-				locator1 = "FrontendDataSet#SELECT_OPTION_HEADER",
-				value1 = "Rename View");
-		}
-	}
-
 	@description = "LPS-165672 - Simplify how actions are shown in the custom views section"
 	@priority = "3"
 	test HasActionsOnlyOnEllipsis {
@@ -288,6 +270,24 @@ definition {
 			AssertElementNotPresent(
 				key_itemName = "Delete View",
 				locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
+		}
+	}
+
+	@description = "LPS-164616. Assert that it's possible to create A new custom view and selected as current view"
+	@priority = "4"
+	test HasOptionToEditName {
+		task ("And Given created custom view") {
+			FDSCustomView.createNewView(key_nameView = "TEST");
+		}
+
+		task ("When open ellisis next to custom view") {
+			Click(locator1 = "FrontendDataSet#ELLIPSIS");
+		}
+
+		task ("Then actions to edit custom view name is available") {
+			AssertElementPresent(
+				locator1 = "FrontendDataSet#SELECT_OPTION_HEADER",
+				value1 = "Rename View");
 		}
 	}
 
@@ -346,21 +346,20 @@ definition {
 	@description = "LPS-168356 - Allow users to rename a custom view"
 	@priority = "3"
 	test NameCanBeUpdated {
-
-		task("And Given created custom view"){
+		task ("And Given created custom view") {
 			FDSCustomView.createNewView(key_nameView = "New View");
 		}
 
-		task("When edit custom view name"){
+		task ("When edit custom view name") {
 			FDSCustomView.renameView(key_nameView = "Second view");
 		}
 
-		task("Then name of custom view is updated in select custom view"){
+		task ("Then name of custom view is updated in select custom view") {
 			Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
 
 			AssertElementPresent(
-				locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW",
-				key_itemName = "Second view");
+				key_itemName = "Second view",
+				locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
 		}
 	}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
@@ -257,6 +257,40 @@ definition {
 		}
 	}
 
+	@description = "LPS-165672 - Simplify how actions are shown in the custom views section"
+	@priority = "3"
+	test HasActionsOnlyOnEllipsis {
+		task ("And Given created custom view") {
+			FDSCustomView.createNewView(key_nameView = "New View");
+		}
+
+		task ("When open ellipsis next to custom view") {
+			Click(locator1 = "FrontendDataSet#SELECT_OPTION_HEADER");
+		}
+
+		task ("Then actions to save and delete views are available in dropdown menu") {
+			FDSCustomView.assertMenuItem(key_menuItem = "Save View");
+
+			FDSCustomView.assertMenuItem(key_menuItem = "Delete View");
+		}
+
+		task ("When open select custom view button") {
+			FDSCustomView.changeCustomView(key_itemName = "Default View");
+
+			Click(locator1 = "FrontendDataSet#SELECT_OPTION_HEADER");
+		}
+
+		task ("Then actions to save and delete views are not available in dropdown menu") {
+			AssertElementNotPresent(
+				key_itemName = "Save View",
+				locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
+
+			AssertElementNotPresent(
+				key_itemName = "Delete View",
+				locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
+		}
+	}
+
 	@description = "LPS-164602 Frontend Dataset - column labels are not localized "
 	@priority = "4"
 	test ManagementBarCanBeLocalized {
@@ -306,6 +340,27 @@ definition {
 			AssertElementPresent(
 				locator1 = "FrontendDataSet#RESET_FILTERS",
 				reset_filter = "Restablecer filtros");
+		}
+	}
+
+	@description = "LPS-168356 - Allow users to rename a custom view"
+	@priority = "3"
+	test NameCanBeUpdated {
+
+		task("And Given created custom view"){
+			FDSCustomView.createNewView(key_nameView = "New View");
+		}
+
+		task("When edit custom view name"){
+			FDSCustomView.renameView(key_nameView = "Second view");
+		}
+
+		task("Then name of custom view is updated in select custom view"){
+			Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
+
+			AssertElementPresent(
+				locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW",
+				key_itemName = "Second view");
 		}
 	}
 


### PR DESCRIPTION
Background
Create automation tests for FDSCustomView

Test Plan:

- Given FDS Sample Portlet
- And Given custom tab
- And Given created custom view
- When edit custom view name
- Then name of custom view is updated in select custom view

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-168356